### PR TITLE
feature: 헤더  position sticky로 변경 및 layout flex-direction 설정

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -21,7 +21,8 @@ export default Header;
 
 const StyledHeaderWrapper = styled.header`
   display: flex;
-  position: fixed;
+  position: sticky;
+  top: 0;
   align-items: center;
   width: 310px;
   height: 41px;

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -15,6 +15,8 @@ export default function AppLayout({ children }: { children: ReactNode }) {
 
 const Centering = styled.div`
   display: flex;
+  flex-direction: column;
+  align-items: center;
   justify-content: center;
 `;
 


### PR DESCRIPTION
1. 헤더 영역의 position이 fixed일 경우, 본문 영역과 영역이 겹쳐지는 현상이 있어 이를 sticky로 변경
2. 헤더와 본문 영역이 차례로 오도록 flex-direction: columns로 변경 및 가운데 정렬