### PR TITLE
[#50] fix: pretendard variable 폰트 적용 오류 해결

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -37,12 +37,10 @@ class MyDocument extends Document {
 
   render(): JSX.Element {
     return (
-      <Html lang='en'>
+      <Html lang='ko'>
         <Head>
           <link
-            rel='preload'
-            as='font'
-            type='font/woff2'
+            rel='stylesheet'
             href='https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.6/dist/web/variable/pretendardvariable-dynamic-subset.css'
           />
           <meta name='viewport' content='initial-scale=1.0, width=device-width' />

--- a/src/styles/font.css
+++ b/src/styles/font.css
@@ -1,7 +1,0 @@
-@font-face {
-  font-family: 'NeoDunggeunmo';
-  src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2001@1.3/NeoDunggeunmo.woff')
-    format('woff');
-  font-weight: normal;
-  font-style: normal;
-}


### PR DESCRIPTION
웹폰트 적용시 css파일 적용해야하기 떄문에 rel:stylesheet 변경
html lang ko로 변경
중복된 css로 파일 삭제