### PR TITLE
[#52] fix: ListBox 컴포넌트 key값을 고유하게 변경

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,13 +23,15 @@
         "react-query": "^3.39.3",
         "styled-components": "^5.3.10",
         "styled-reset": "^4.4.6",
-        "typescript": "5.0.4"
+        "typescript": "5.0.4",
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@svgr/webpack": "^7.0.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@types/styled-components": "^5.1.26",
+        "@types/uuid": "^9.0.1",
         "@typescript-eslint/eslint-plugin": "^5.59.1",
         "@typescript-eslint/parser": "^5.59.1",
         "babel-plugin-styled-components": "^2.1.1",
@@ -3435,6 +3437,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -9798,6 +9806,14 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
@@ -12417,6 +12433,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
       "dev": true
     },
     "@types/yargs": {
@@ -16675,6 +16697,11 @@
     "use-sync-external-store": {
       "version": "1.2.0",
       "requires": {}
+    },
+    "uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-to-istanbul": {
       "version": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -28,13 +28,15 @@
     "react-query": "^3.39.3",
     "styled-components": "^5.3.10",
     "styled-reset": "^4.4.6",
-    "typescript": "5.0.4"
+    "typescript": "5.0.4",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@svgr/webpack": "^7.0.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@types/styled-components": "^5.1.26",
+    "@types/uuid": "^9.0.1",
     "@typescript-eslint/eslint-plugin": "^5.59.1",
     "@typescript-eslint/parser": "^5.59.1",
     "babel-plugin-styled-components": "^2.1.1",

--- a/src/components/list/index.tsx
+++ b/src/components/list/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useId, useState } from 'react';
 
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
@@ -93,7 +93,7 @@ const List = ({ products, queryRes }: ListPageProps) => {
           <form onSubmit={onSubmit}>
             {products.map(product => (
               <ListBox
-                key={`${product.productId} key`}
+                key={`${product.productId}`}
                 product={product}
                 listClickHandler={listClickHandler}
               />

--- a/src/hooks/useSearchProduct.ts
+++ b/src/hooks/useSearchProduct.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { useInfiniteQuery } from '@tanstack/react-query';
+import { v4 as uuidv4 } from 'uuid';
 
 import { IMG_FILTER, SORT } from '@/constant/list';
 import { getProductsApi } from '@/utils/api';
@@ -35,7 +36,7 @@ function useSearchProducts(userSearch: string) {
         originDatas.pages.reduce((acc, page) => {
           const processedPageData = page.items.map(item => {
             const tmpProduct: Product = {
-              productId: item.productId,
+              productId: `${item.productId} ${uuidv4()}`,
               title: item.title.replaceAll('<b>', '').replaceAll('</b>', ''),
               image: item.image,
               price: Number(item.lprice),


### PR DESCRIPTION
### 문제 상황
![2023-05-22 15;12;29](https://github.com/SobiSa-Expense-Hunter/SobiSa/assets/108770949/b2da5cef-d06b-4539-9c53-057354276d29)

### 문제 원인
기존 api에서 넘어오는 productid를 ListBox컴포넌트의 key로 사용한 점에서 문제 발생
(이상하게 푸바오만 검색하고 나면 에러가 나와서,, )

![image](https://github.com/SobiSa-Expense-Hunter/SobiSa/assets/108770949/c592d3b5-8cad-4b99-8cb1-8a6ccc881257)
**특정 제품의 productid가 고유하지 않았어요.**

### 문제 해결
uuid 라이브러리를 이용해 key를 고유하게 수정
(uuid를 공식 홈페이지에서 사용하라고 나와있길래 해당 라이브러리를 사용했어요)
https://react.dev/learn/rendering-lists#where-to-get-your-key

![image](https://github.com/SobiSa-Expense-Hunter/SobiSa/assets/108770949/a4e74c76-dc62-4c86-a4bd-a48c7edd2c56)
`productid uuid` 이런식으로 공백을 이용해 한칸 띄워서 만들어 두었습니다.
이것때문에 Product 인터페이스를 수정하기 좀 애매하다고 생각해서요.

productid가 필요한 상황에서는 공백을 슬라이싱해서 사용하시면 될 것 같습니다.
혹시 더 좋은 방법이 있으시다면 언제든 알려주세요~

### 기타
혹시 이렇게 수정하고 나서도 뜬다면,, 다른 원인이 있는지 수정해보도록 할게요
에러 있으면 언제든 알려주세요!