### PR TITLE
[#58] IOS 환경에서 임명장 이미지 다운로드 오류

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -42,6 +42,7 @@ class MyDocument extends Document {
           <link
             rel='stylesheet'
             href='https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.6/dist/web/variable/pretendardvariable-dynamic-subset.css'
+            crossOrigin='anonymous'
           />
           <meta name='viewport' content='initial-scale=1.0, width=device-width' />
 


### PR DESCRIPTION
- 사파리의 경우 캔버스에 이미지를 그리고 시간이 필요.
- 라이브러리의 toPng 대신 toSvg을 이용해 1차 변환 후 해당 컴포넌트에서 캔버스에 이미지를 그린 후 300 ms 지연을 하는 toPng 함수 추가