### PR TITLE
[#69] fix: 이미지 깨지는 현상 수정

### DIFF
--- a/src/components/modal/ChoseProductModal.tsx
+++ b/src/components/modal/ChoseProductModal.tsx
@@ -48,17 +48,12 @@ const ChoseProductModal = ({ onClose, onSubmit, title, image }: ChoseProductModa
 export default ChoseProductModal;
 
 const ImageBox = styled.div`
-  width: 100%;
-  height: 100%;
-  max-width: 111px;
-  max-height: 111px;
   position: relative;
 `;
 
 const ProductImage = styled.img`
-  object-fit: cover;
-  width: 100%;
-  height: 100%;
+  width: 111px;
+  height: 111px;
 `;
 
 const ChoseModalContainer = styled(ModalContainer)`


### PR DESCRIPTION
- image의 width, height가 100%로 세로가 긴 이미지가 영역을 벗어나는 현상 발생
- 리스트와 동일한 이미지가 보이도록 스타일 변경
<img width="390" alt="image" src="https://github.com/SobiSa-Expense-Hunter/SobiSa/assets/30384031/f1cfef93-81d0-4b67-b600-e8f8c852d222">
