### PR TITLE
[#67] fix: svh 호환이 안되는 브라우저에서는 vh 적용되도록 수정

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -31,7 +31,12 @@ export const FixedWidth = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  height: 100svh;
+  height: 100vh;
+
+  @supports (height: 100svh) {
+    height: 100svh;
+  }
+
   @media (max-width: 768px) {
     width: 100%;
   }


### PR DESCRIPTION
`@supports` 구문 추가로 해결
