### PR TITLE
[#78] feature: 임명장 상품명이 모두 보이도록 수정

### DIFF
--- a/src/components/results/Certificate.tsx
+++ b/src/components/results/Certificate.tsx
@@ -120,7 +120,13 @@ const StickerStamp = styled(motion.span)``;
 
 const ProductName = styled(AwardXLarge)<{ length: number }>`
   text-align: right;
-  word-break: break-all;
+  word-break: keep-all;
+  overflow-wrap: break-word;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  max-width: ${props => (props.length > 14 ? 'calc(100% - 16px)' : '100%')};
 `;
 
 const Certificate = (

--- a/src/components/results/Certificate.tsx
+++ b/src/components/results/Certificate.tsx
@@ -154,11 +154,8 @@ const Certificate = (
           </SmallFlexEnd>
           <AwardXLarge
             style={{
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              width: '100%',
               textAlign: 'right',
+              wordBreak: 'keep-all',
             }}
           >
             {title}

--- a/src/components/results/Certificate.tsx
+++ b/src/components/results/Certificate.tsx
@@ -118,6 +118,11 @@ const Sticker = styled(motion.span)`
 
 const StickerStamp = styled(motion.span)``;
 
+const ProductName = styled(AwardXLarge)<{ length: number }>`
+  text-align: right;
+  word-break: break-all;
+`;
+
 const Certificate = (
   { alternatives }: { alternatives: Alternatives[] },
   ref: ForwardedRef<HTMLDivElement>,
@@ -152,14 +157,7 @@ const Certificate = (
               {new Date().toISOString().substring(0, 19).replace('T', ' ')}
             </AwardXXSmall>
           </SmallFlexEnd>
-          <AwardXLarge
-            style={{
-              textAlign: 'right',
-              wordBreak: 'keep-all',
-            }}
-          >
-            {title}
-          </AwardXLarge>
+          <ProductName length={title.length}>{title}</ProductName>
         </ColumnFlexEndWithBorderBottom>
         <ContentColumnFlex>
           <ContentRowFlex>

--- a/src/components/results/Certificate.tsx
+++ b/src/components/results/Certificate.tsx
@@ -120,13 +120,7 @@ const StickerStamp = styled(motion.span)``;
 
 const ProductName = styled(AwardXLarge)<{ length: number }>`
   text-align: right;
-  word-break: keep-all;
-  overflow-wrap: break-word;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
-  overflow: hidden;
-  max-width: ${props => (props.length > 14 ? 'calc(100% - 16px)' : '100%')};
+  word-break: 'keep-all';
 `;
 
 const Certificate = (


### PR DESCRIPTION
2줄로 표시하려 하였으나, 키워드 페이지에서 이미 제목에 표시할 내용을 14글자 이내로 잘라둔다는 점,
이를 표시할 때 css속성 word-break 속성을 keep-all로 지정하면 글자가 잘리듯이 보이는 현상이 있으며, 또한 이러한 점때문에 break-all 로 변경하면 더 적은 키워드일 경우 글자가 중간에 잘려 보기 불편하다는 점,
위 두 가지 이유로 임명장 상품명이 2줄이 넘칠 경우 자르는 부분은 제거하여 모두 표시하게 함.
한글로 된 상품명 표시 시, 14글자가 모두 2줄 안에 보이는 모습 확인