### PR TITLE
[#83] style: 제품 List Box 양옆 padding 추가

### DIFF
--- a/src/components/list/styles.tsx
+++ b/src/components/list/styles.tsx
@@ -9,7 +9,7 @@ export const StyledListContainer = styled.div<{ select?: boolean }>`
   }
   display: flex;
   align-items: center;
-  padding: 20px 0px;
+  padding: 20px 15px;
   gap: 16px;
   margin: 0;
 


### PR DESCRIPTION
<img src='https://github.com/SobiSa-Expense-Hunter/SobiSa/assets/108770949/aa02d149-aea3-4b46-a61d-76e622f7959f' width='300px' />

- 디자인 수정사항 반영