### PR TITLE
[#89] fix: list page NotFound 하단 버튼 라우팅 수정

### DIFF
--- a/src/components/list/NotFound.tsx
+++ b/src/components/list/NotFound.tsx
@@ -19,7 +19,7 @@ function NotFound() {
       <Font.Small>검색하신 물건과 관련된 결과가 하나도 없습니다! </Font.Small>
       <Font.Small>오타를 내신 건 아닌가요?</Font.Small>
       <MarginBox margin='87px' />
-      <Link href='/search'>
+      <Link href='/' replace>
         <Buttons.BottomButton>이전으로</Buttons.BottomButton>
       </Link>
       <MarginBox margin='66px' />


### PR DESCRIPTION
'/search'로 라우팅 되어있던 것을 '/' 로 수정
잘못 검색된 검색어를 뒤로가기를 누르면 다시 검색되기에,
Link 컴포넌트에 replace 속성 추가하여 뒤로가기 방지