### PR TITLE
 [#92] style: body에 user-select: none 추가

### DIFF
--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -87,6 +87,7 @@ const SearchEnterInput = styled.input`
   outline: none;
   border: solid 1px white;
   width: 100%;
+  width: 100%;
   height: 100%;
   padding: 20px;
   max-width: 210px;

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -85,7 +85,8 @@ const SearchEnterInput = styled.input`
   white-space: nowrap;
   border-radius: 6px 0 0 6px;
   outline: none;
-  border: none;
+  border: solid 1px white;
+  width: 100%;
   width: 100%;
   height: 100%;
   padding: 20px;

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -85,8 +85,7 @@ const SearchEnterInput = styled.input`
   white-space: nowrap;
   border-radius: 6px 0 0 6px;
   outline: none;
-  border: solid 1px white;
-  width: 100%;
+  border: none;
   width: 100%;
   height: 100%;
   padding: 20px;

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -87,7 +87,6 @@ const SearchEnterInput = styled.input`
   outline: none;
   border: solid 1px white;
   width: 100%;
-  width: 100%;
   height: 100%;
   padding: 20px;
   max-width: 210px;

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -10,6 +10,9 @@ const GlobalStyle = createGlobalStyle`${css`
 
   body {
     background-color: ${({ theme }) => theme.colors.gray[1]};
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
   }
 
   button {


### PR DESCRIPTION
SearchInput의 내부 입력 공간을 경계로 경계선이 생긴다고 판단
따라서 경계선을 따라 배경색과 동일한 border solid 1px white 적용

- ios - whail 브라우저에서만 생기는 문제
- 해당 경계선을 따라 주황색 border line 이 생기는 문제

였기에 일단 이런 방식으로 접근을 해봤어요.

제 컴퓨터에서는 실시간으로 해결되는지 확인이 안돼서.. 해결을 한건지 잘 모르겠네요 😿 