### PR TITLE
Refactor/#106 layout component

### DIFF
--- a/src/assets/Images.tsx
+++ b/src/assets/Images.tsx
@@ -2,18 +2,24 @@ import Image from 'next/image';
 
 const IMG_PATH = '/assets';
 
-export const MainImage = () => {
+interface ImageSizeProps {
+  width: number;
+  height: number;
+}
+
+export const MainImage = ({ width, height }: ImageSizeProps) => {
   return (
     <Image
       src={`${IMG_PATH}/image/main.png`}
-      width={220}
-      height={220}
+      width={width}
+      height={height}
       alt='소비사 main img'
       quality={100}
       loading='lazy'
     />
   );
 };
+
 export const LineImage = () => {
   return <Image src={`${IMG_PATH}/image_line.svg`} width={220} height={220} alt='소비사 캐릭터' />;
 };

--- a/src/components/common/layout/index.ts
+++ b/src/components/common/layout/index.ts
@@ -1,0 +1,62 @@
+import styled, { css } from 'styled-components';
+
+interface FlexProps extends BoxProps {
+  flexDirection?: 'row' | 'column' | 'row-reverse' | 'column-reverse';
+  justifyContent?: 'flex-start' | 'flex-end' | 'space-between' | 'center' | 'space-around';
+  alignItems?: 'center' | 'flex-start' | 'flex-end' | 'stretch' | 'baseline';
+  flexWrap?: 'nowrap' | 'wrap';
+  gap?: string;
+}
+
+interface BoxProps {
+  display?: 'none' | 'block' | 'inline' | 'inline-block' | 'flex';
+  margin?: string;
+  padding?: string;
+  width?: string;
+  height?: string;
+  maxWidth?: string;
+  maxHeight?: string;
+}
+
+const SizeAndMarginAndPaddingProperty = css<FlexProps>`
+  width: ${({ width }) => width || 'none'};
+  height: ${({ height }) => height || 'none'};
+  margin: ${({ margin }) => margin || 'none'};
+  padding: ${({ padding }) => padding || 'none'};
+  max-width: ${({ maxWidth }) => maxWidth || 'none'};
+  max-height: ${({ maxHeight }) => maxHeight || 'none'};
+`;
+
+const FlexProperty = css<FlexProps>`
+  justify-content: ${({ justifyContent }) => justifyContent || 'none'};
+  align-items: ${({ alignItems }) => alignItems || 'none'};
+  gap: ${({ gap }) => gap || '0'};
+  flex-wrap: ${({ flexWrap }) => flexWrap || 'nowrap'};
+`;
+
+export const VStack = styled.div<FlexProps>`
+  display: flex;
+  flex-direction: column;
+
+  ${FlexProperty}
+  ${SizeAndMarginAndPaddingProperty}
+`;
+
+export const HStack = styled.div<FlexProps>`
+  display: flex;
+  flex-direction: row;
+
+  ${FlexProperty}
+  ${SizeAndMarginAndPaddingProperty}
+`;
+
+export const Fixed = styled.div`
+  position: fixed;
+`;
+
+export const Box = styled.div<FlexProps>`
+  display: ${({ display }) => display || 'block'};
+
+  ${FlexProperty}
+  ${SizeAndMarginAndPaddingProperty}
+`;

--- a/src/components/common/layout/index.ts
+++ b/src/components/common/layout/index.ts
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 
-interface FlexProps extends BoxProps {
+interface FlexProps extends SizeAndMarginAndPaddingProps {
   flexDirection?: 'row' | 'column' | 'row-reverse' | 'column-reverse';
   justifyContent?: 'flex-start' | 'flex-end' | 'space-between' | 'center' | 'space-around';
   alignItems?: 'center' | 'flex-start' | 'flex-end' | 'stretch' | 'baseline';
@@ -8,55 +8,55 @@ interface FlexProps extends BoxProps {
   gap?: string;
 }
 
-interface BoxProps {
-  display?: 'none' | 'block' | 'inline' | 'inline-block' | 'flex';
+interface SizeAndMarginAndPaddingProps {
   margin?: string;
   padding?: string;
   width?: string;
   height?: string;
   maxWidth?: string;
   maxHeight?: string;
+  minWidth?: string;
+  minHeight?: string;
 }
 
-const SizeAndMarginAndPaddingProperty = css<FlexProps>`
-  width: ${({ width }) => width || 'none'};
-  height: ${({ height }) => height || 'none'};
-  margin: ${({ margin }) => margin || 'none'};
-  padding: ${({ padding }) => padding || 'none'};
-  max-width: ${({ maxWidth }) => maxWidth || 'none'};
-  max-height: ${({ maxHeight }) => maxHeight || 'none'};
+const SizeAndMarginAndPaddingProperty = css<SizeAndMarginAndPaddingProps>`
+  width: ${({ width }) => width || ''};
+  height: ${({ height }) => height || ''};
+  margin: ${({ margin }) => margin || ''};
+  padding: ${({ padding }) => padding || ''};
+  max-width: ${({ maxWidth }) => maxWidth || ''};
+  max-height: ${({ maxHeight }) => maxHeight || ''};
+  min-width: ${({ minWidth }) => minWidth || ''};
+  min-height: ${({ minHeight }) => minHeight || ''};
 `;
 
 const FlexProperty = css<FlexProps>`
-  justify-content: ${({ justifyContent }) => justifyContent || 'none'};
-  align-items: ${({ alignItems }) => alignItems || 'none'};
+  display: flex;
+  justify-content: ${({ justifyContent }) => justifyContent || ''};
+  align-items: ${({ alignItems }) => alignItems || ''};
   gap: ${({ gap }) => gap || '0'};
   flex-wrap: ${({ flexWrap }) => flexWrap || 'nowrap'};
+  flex-direction: ${({ flexDirection }) => flexDirection || ''};
 `;
 
-export const VStack = styled.div<FlexProps>`
-  display: flex;
+export const Flex = styled.div<FlexProps>`
+  ${FlexProperty}
+  ${SizeAndMarginAndPaddingProperty}
+`;
+
+export const VStack = styled(Flex)`
   flex-direction: column;
-
-  ${FlexProperty}
-  ${SizeAndMarginAndPaddingProperty}
 `;
 
-export const HStack = styled.div<FlexProps>`
-  display: flex;
+export const HStack = styled(Flex)`
   flex-direction: row;
-
-  ${FlexProperty}
-  ${SizeAndMarginAndPaddingProperty}
 `;
 
 export const Fixed = styled.div`
   position: fixed;
 `;
 
-export const Box = styled.div<FlexProps>`
-  display: ${({ display }) => display || 'block'};
-
-  ${FlexProperty}
+export const Box = styled.div<SizeAndMarginAndPaddingProps>`
+  display: 'block';
   ${SizeAndMarginAndPaddingProperty}
 `;

--- a/src/components/keyword/index.tsx
+++ b/src/components/keyword/index.tsx
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 import * as Icon from '@/assets/Icons';
 import { useSearchDispatch } from '@/components/SearchProvider';
 import { BottomButton } from '@/components/common/buttons';
-import MarginBox from '@/components/common/marginBox';
+import * as Layout from '@/components/common/layout';
 import * as Style from '@/components/keyword/style';
 import * as Font from '@/styles/font';
 import { Product } from '@/types/product';
@@ -43,40 +43,45 @@ function Keyword({ product, allKeyword }: { product: Product; allKeyword: string
   };
 
   return (
-    <Style.Container>
-      <div>
+    <Layout.VStack
+      justifyContent='space-around'
+      margin='36px 0 0'
+      height='100%'
+      width='100%'
+      maxWidth='310px'
+      alignItems='stretch'
+    >
+      <Layout.Box>
         <Style.KeywordPageFont.Main>표시할 상품 키워드를 선택해 주세요.</Style.KeywordPageFont.Main>
-        <MarginBox margin='4px' />
+        <Layout.Box height='4px' />
         <Style.KeywordPageFont.Sub>
           멋진 임명장을 위해선 7~14글자 사이가 좋아요!
         </Style.KeywordPageFont.Sub>
-        <MarginBox margin='24px' />
-        <Style.Keyword>
+        <Layout.Box height='24px' />
+        <Layout.HStack flexWrap='wrap' gap='8px 6px'>
           {allKeyword.map(keyword => (
-            <Style.KeywordWrapper
+            <Style.KeywordButton
               key={uuidv4()}
               onClick={() => keywordHandler(keyword)}
               isSelected={selectedKeywords.includes(keyword)}
             >
               {keyword}
-            </Style.KeywordWrapper>
+            </Style.KeywordButton>
           ))}
-        </Style.Keyword>
-        <MarginBox margin='56px' />
-        <Style.FlexColWrapper>
+        </Layout.HStack>
+        <Layout.Box margin='56px' />
+        <Layout.VStack alignItems='stretch' gap='16px'>
           <Style.Span>{String(selectedKeywords).replaceAll(',', ' ')}</Style.Span>
-          <Style.FlexRowWrapper>
+          <Layout.HStack alignItems='center'>
             <Font.SmallOrange style={{ flex: 1 }}>{alertMessage}</Font.SmallOrange>
             <Style.ResetBtn type='button' onClick={titleResetHandler}>
               <Icon.InitializationIcon />
             </Style.ResetBtn>
-          </Style.FlexRowWrapper>
-        </Style.FlexColWrapper>
-      </div>
-      <Style.ButtonBox>
-        <BottomButton onClick={nextPageHandler}>다음으로</BottomButton>
-      </Style.ButtonBox>
-    </Style.Container>
+          </Layout.HStack>
+        </Layout.VStack>
+      </Layout.Box>
+      <BottomButton onClick={nextPageHandler}>다음으로</BottomButton>
+    </Layout.VStack>
   );
 }
 

--- a/src/components/keyword/style.ts
+++ b/src/components/keyword/style.ts
@@ -3,16 +3,6 @@ import styled from 'styled-components';
 import { DefaultInput } from '@/components/common/input';
 import * as Font from '@/styles/font';
 
-export const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  margin-top: 36px;
-  max-width: 310px;
-  width: 100%;
-  justify-content: space-around;
-  height: 100%;
-`;
-
 export const KeywordPageFont = {
   Main: styled(Font.Large)``,
   Sub: styled(Font.Medium)`
@@ -21,35 +11,7 @@ export const KeywordPageFont = {
   `,
 };
 
-export const FlexRowWrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-`;
-
-export const ButtonBox = styled.div`
-  display: flex;
-  justify-content: center;
-`;
-
-export const FlexColWrapper = styled.div`
-  display: flex;
-  max-width: 310px;
-  align-items: center;
-  gap: 16px;
-  flex-direction: column;
-  align-items: stretch;
-`;
-
-export const Keyword = styled.div`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  flex-wrap: wrap;
-  align-content: center;
-  gap: 8px 6px;
-`;
-
-export const KeywordWrapper = styled.button<{ isSelected: boolean }>`
+export const KeywordButton = styled.button<{ isSelected: boolean }>`
   background: ${({ isSelected, theme }) => {
     if (isSelected) return theme.colors.mainColor;
     return theme.colors.gray[0];

--- a/src/components/list/NotFound.tsx
+++ b/src/components/list/NotFound.tsx
@@ -1,36 +1,26 @@
-/* eslint-disable import/no-cycle */
-import React from 'react';
-
 import Image from 'next/image';
 import Link from 'next/link';
-import styled from 'styled-components';
 
 import * as Buttons from '@/components/common/buttons';
-import MarginBox from '@/components/common/marginBox';
+import * as Layout from '@/components/common/layout';
 import * as Font from '@/styles/font';
 
 function NotFound() {
   return (
-    <NotFoundWrapper>
+    <Layout.VStack alignItems='center'>
       <Image src='/graphics/notFound.gif' alt='not Found' height={220} width={220} unoptimized />
-      <MarginBox margin='32px' />
+      <Layout.Box height='32px' />
       <Font.MediumOrange>정말 그걸 검색하신 게 맞나요? </Font.MediumOrange>
-      <MarginBox margin='16px' />
+      <Layout.Box height='16px' />
       <Font.Small>검색하신 물건과 관련된 결과가 하나도 없습니다! </Font.Small>
       <Font.Small>오타를 내신 건 아닌가요?</Font.Small>
-      <MarginBox margin='87px' />
+      <Layout.Box height='87px' />
       <Link href='/' replace>
         <Buttons.BottomButton>이전으로</Buttons.BottomButton>
       </Link>
-      <MarginBox margin='66px' />
-    </NotFoundWrapper>
+      <Layout.Box margin='66px' />
+    </Layout.VStack>
   );
 }
 
 export default NotFound;
-
-const NotFoundWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-`;

--- a/src/components/list/index.tsx
+++ b/src/components/list/index.tsx
@@ -106,15 +106,14 @@ const List = ({ products, queryRes }: ListPageProps) => {
 
           <div ref={ref} />
           {isFetching && hasNextPage && (
-            <Layout.Box
+            <Layout.Flex
               width='310px'
               maxHeight='151px'
-              display='flex'
               justifyContent='center'
               alignItems='center'
             >
               <LoadingSpinner />
-            </Layout.Box>
+            </Layout.Flex>
           )}
         </Style.Scroll>
       </ListLayout>

--- a/src/components/list/index.tsx
+++ b/src/components/list/index.tsx
@@ -6,7 +6,7 @@ import { useInView } from 'react-intersection-observer';
 
 import * as SVG from '@/assets/Icons';
 import { useSearchDispatch } from '@/components/SearchProvider';
-import MarginBox from '@/components/common/marginBox';
+import * as Layout from '@/components/common/layout';
 import ListBox from '@/components/list/ListBox';
 import LoadingSpinner from '@/components/list/LoadingSpinner';
 import * as Style from '@/components/list/styles';
@@ -40,9 +40,9 @@ const List = ({ products, queryRes }: ListPageProps) => {
   if (isLoading || products === undefined)
     return (
       <ListLayout>
-        <Style.JustifyCenter>
+        <Layout.VStack width='100%' height='100%' alignItems='center' justifyContent='center'>
           <LoadingSpinner />
-        </Style.JustifyCenter>
+        </Layout.VStack>
       </ListLayout>
     );
 
@@ -77,11 +77,11 @@ const List = ({ products, queryRes }: ListPageProps) => {
 
   return (
     <>
-      <Style.Fixed>
+      <Layout.Fixed style={{ bottom: '26px' }}>
         <Style.TopBtn type='button' onClick={() => topBtnHandler()}>
           <SVG.TopIcon />
         </Style.TopBtn>
-      </Style.Fixed>
+      </Layout.Fixed>
 
       <ListLayout>
         <Style.Scroll ref={scrollRef}>
@@ -106,26 +106,32 @@ const List = ({ products, queryRes }: ListPageProps) => {
 
           <div ref={ref} />
           {isFetching && hasNextPage && (
-            <Style.ListBoxSize>
+            <Layout.Box
+              width='310px'
+              maxHeight='151px'
+              display='flex'
+              justifyContent='center'
+              alignItems='center'
+            >
               <LoadingSpinner />
-            </Style.ListBoxSize>
+            </Layout.Box>
           )}
         </Style.Scroll>
       </ListLayout>
-      <MarginBox margin='10px' />
+      <Layout.Box height='10px' />
     </>
   );
 };
 
 export default List;
 
-export function ListLayout({ children }: { children: React.ReactElement }) {
+function ListLayout({ children }: { children: React.ReactElement }) {
   return (
-    <Style.JustifyFlexStart>
-      <MarginBox margin='15px' />
+    <Layout.VStack height='100%' alignItems='center' width='100%'>
+      <Layout.Box height='32px' />
       <SearchInput />
-      <MarginBox margin='32px' />
+      <Layout.Box height='15px' />
       {children}
-    </Style.JustifyFlexStart>
+    </Layout.VStack>
   );
 }

--- a/src/components/list/styles.ts
+++ b/src/components/list/styles.ts
@@ -13,11 +13,6 @@ export const ListBoxSizeCss = css`
   height: 151px;
 `;
 
-export const ListBoxSize = styled.div`
-  ${ListBoxSizeCss}
-  justify-content: center;
-`;
-
 export const StyledListContainer = styled.div<{ select?: boolean }>`
   ${ListBoxSizeCss}
 
@@ -49,11 +44,6 @@ export const Scroll = styled.div`
   &::-webkit-scrollbar-thumb {
     background: ${({ theme }) => theme.colors.gray[2]};
   }
-`;
-
-export const Fixed = styled.div`
-  position: fixed;
-  bottom: 26px;
 `;
 
 export const TopBtn = styled.button`
@@ -91,21 +81,4 @@ export const Title = styled(Font.Medium)`
 
 export const ItemClass = styled(Font.Small)`
   margin-top: 8px;
-`;
-
-/* Layout */
-export const FlexDefultCentering = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 100%;
-  height: 100%;
-`;
-
-export const JustifyFlexStart = styled(FlexDefultCentering)`
-  justify-content: flex-start;
-`;
-
-export const JustifyCenter = styled(FlexDefultCentering)`
-  justify-content: center;
 `;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,10 +1,8 @@
-import React from 'react';
-
 import { useRouter } from 'next/router';
-import styled from 'styled-components';
 
 import { MainImage } from '@/assets/Images';
 import SearchInput from '@/components/SearchInput';
+import * as Layout from '@/components/common/layout';
 import FacebookButton from '@/components/common/share/FacebookButton';
 import KakaoButton from '@/components/common/share/KakaoButton';
 import LinkButton from '@/components/common/share/LinkButton';
@@ -24,39 +22,20 @@ function Home() {
   }
 
   return (
-    <Container>
+    <Layout.VStack margin='20px 0 0' width='100%' alignItems='center'>
       <Font.Medium>지금 뭘 사고 싶나요?</Font.Medium>
       <Font.Large>소비사와 같이 고민해 봐요!</Font.Large>
-      <ImageBox>
-        <MainImage />
-      </ImageBox>
+      <Layout.Box margin='16px 0px'>
+        <MainImage width={220} height={220} />
+      </Layout.Box>
       <SearchInput />
-      <LinkBox>
+      <Layout.HStack margin='66px 0 0' gap='8px'>
         <FacebookButton pageUrl={url} />
         <TwitterButton pageUrl={url} sendText={text} />
         <KakaoButton title={title} description={text} webUrl={url} />
         <LinkButton pageUrl={url} />
-      </LinkBox>
-    </Container>
+      </Layout.HStack>
+    </Layout.VStack>
   );
 }
 export default Home;
-
-const ImageBox = styled.div`
-  margin: 16px 0px;
-`;
-
-const LinkBox = styled.div`
-  margin-top: 66px;
-  display: flex;
-  gap: 8px;
-`;
-
-const Container = styled.div`
-  margin-top: 20px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-`;

--- a/src/pages/list/index.tsx
+++ b/src/pages/list/index.tsx
@@ -10,7 +10,6 @@ function ListPage() {
   if (Array.isArray(search) || !search) search = '';
   const { products, queryRes } = useSearchProducts(search);
 
-  // TO-DO : SEARCH BAR 공백 예외 처리
   return <List products={products} queryRes={queryRes} />;
 }
 


### PR DESCRIPTION
## 작업 요약
- 레이아웃 전용 컴포넌트인 HStack, VStack, Box 컴포넌트를 제작했어요.
- 적용 페이지 및 컴포넌트: `search('/')` ,`list`, `keyword`,  `notFound`
- About 페이지에서도 해당 레이아웃 컴포넌트를 사용해서 작업을 해볼까 싶어서 작업을 했어요.

## 기대 효과
- 기능 의미가 불분명했던 레이아웃을 잡기 위한 wrapper 나 containor 등의 네이밍을 하지 않아도 되요
(ex. `<NotFoundWrapper>` -> `<Layout.VStack alignItems='center'>` )

- 각 레이아웃 wrapper 마다 따로 작업해줬던 보일러플레이트의 양을 줄일 수 있어요.
(특히 이번 작업에선 flex관련 속성들이 눈에 많이 띄었어요.)

- JSX 부분을 보았을때 해당 컴포넌트가 어떤 기능을 하는 컴포넌트인지 코드상에서 알 수 있어요.


## 한계점
- 제가 작업하던 부분에서 반복적으로 사용하던 속성을 컴포넌트로 교체한거라,
지금 만들어둔 컴포넌트가 모든 상황을 포괄하진 못할 것 같아요.

- List 내부에서 사용되는 `ListBox` (내부 이미지, 제품 이름을 담은 컴포넌트)에는 
해당 레이아웃 컴포넌트를 적용해두지 못했어요. 
  - 급하게 넣으려다보니 기존 레이아웃을 싹 다 잡아줘야 한다는 점
  - 스타일 컴포넌트로 해당 레이아웃 컴포넌트를 상속받아 쓰는게 과연 맞는 것인지 잘 모르겠다는 점
  
 따라서 일단은 해당 부분은 작업을 진행하지 않았어요.

- 제가 혼자 급하게 짜본거라 부족한 부분이 많이 있을 것 같아요.
사용하면서 필요하다 생각되는 부분을 추가 및 제거하면서 사용하면 어떨까 싶어요.

---

## 참고 자료
아무래도 class 101 코드 컨벤션 자료랑 이전에 Chakra ui를 사용했던 기억으로 작업을 했어요.  _chacra ui 참 편하긴 했었죠,,,_

| class101 코드 자료 1| class101 코드 자료 2|
|--------|--------|
| ![image](https://github.com/SobiSa-Expense-Hunter/SobiSa/assets/108770949/ff2391cd-9da0-47d3-9df5-7531e48829fa) | ![image](https://github.com/SobiSa-Expense-Hunter/SobiSa/assets/108770949/8504fe69-165c-4aca-b619-b10cd80ef94a) |

[Class 101 코드 리뷰 가이드 링크](https://jobs.class101.net/474202c9-4585-4a01-a418-67e4a4feff79#d466b1e325bd45249a38322e309cf194)