### PR TITLE
기기별 layout 관련 이슈 수정 (error, main, header, savingAmount, keyword page)

### DIFF
--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -80,7 +80,6 @@ const SearchInputContainer = styled.div`
   max-width: 310px;
   justify-content: space-between;
   background-color: ${({ theme }) => theme.colors.mainColor};
-  z-index: 1;
 `;
 const SearchInputBox = styled.div`
   width: 80%;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -41,11 +41,11 @@ const Button = styled.button`
 const HeaderWrapper = styled.header`
   display: flex;
   position: sticky;
-  top: 0;
+  top: -1px;
   align-items: center;
   width: 310px;
-  height: 41px;
-  min-height: 41px;
+  height: 42px;
+  min-height: 42px;
   background-color: white;
   padding: 5vh 0 2vh;
   @media (max-width: 768px) {

--- a/src/components/common/Modal.ts
+++ b/src/components/common/Modal.ts
@@ -23,7 +23,7 @@ export const Background = styled.div<{ show: boolean }>`
   left: 0;
   width: 100%;
   height: 100%;
-  z-index: 2;
+  z-index: 1;
   backdrop-filter: blur(2px);
   background-color: rgba(0, 0, 0, 0.5);
   animation: 0.2s ${props => (props.show ? FadeIn : FadeOut)};

--- a/src/components/common/error/index.tsx
+++ b/src/components/common/error/index.tsx
@@ -14,8 +14,13 @@ interface ErrorProps {
 
 function CustomError({ mainTitle, subTextLines, buttonText }: ErrorProps) {
   return (
-    <Layout.VStack alignItems='center' height='100%' justifyContent='space-around'>
-      <Layout.VStack alignItems='center'>
+    <Layout.VStack
+      alignItems='center'
+      height='100%'
+      justifyContent='space-around'
+      style={{ overflow: 'hidden' }}
+    >
+      <Layout.VStack alignItems='center' style={{ overflow: 'auto' }}>
         <Image src='/graphics/notFound.gif' alt='not Found' height={220} width={220} unoptimized />
         <Layout.Box height='32px' />
         <Font.MediumOrange>{mainTitle}</Font.MediumOrange>

--- a/src/components/common/error/index.tsx
+++ b/src/components/common/error/index.tsx
@@ -14,27 +14,29 @@ interface ErrorProps {
 
 function CustomError({ mainTitle, subTextLines, buttonText }: ErrorProps) {
   return (
-    <Layout.VStack
-      alignItems='center'
-      height='100%'
-      justifyContent='space-around'
-      style={{ overflow: 'hidden' }}
-    >
-      <Layout.VStack alignItems='center' style={{ overflow: 'auto' }}>
-        <Image src='/graphics/notFound.gif' alt='not Found' height={220} width={220} unoptimized />
-        <Layout.Box height='32px' />
-        <Font.MediumOrange>{mainTitle}</Font.MediumOrange>
-        <Layout.VStack margin='16px 0 0' maxWidth='310px' alignItems='center'>
-          {subTextLines.map(textLine => (
-            <Font.Small key={uuid()}> {textLine} </Font.Small>
-          ))}
+    <Layout.FixButtonBottom height='auto' alignItems='center' padding='30px 0 30px'>
+      <Layout.VStack justifyContent='center' margin='0 0 5vh 0'>
+        <Layout.VStack alignItems='center'>
+          <Image
+            src='/graphics/notFound.gif'
+            alt='not Found'
+            height={220}
+            width={220}
+            unoptimized
+          />
+          <Layout.Box height='5vh' />
+          <Font.MediumOrange>{mainTitle}</Font.MediumOrange>
+          <Layout.VStack margin='16px 0 0' maxWidth='310px' alignItems='center'>
+            {subTextLines.map(textLine => (
+              <Font.Small key={uuid()}> {textLine} </Font.Small>
+            ))}
+          </Layout.VStack>
         </Layout.VStack>
-        <Layout.Box height='87px' />
       </Layout.VStack>
       <Link href='/' replace>
         <Buttons.BottomButton>{buttonText}</Buttons.BottomButton>
       </Link>
-    </Layout.VStack>
+    </Layout.FixButtonBottom>
   );
 }
 

--- a/src/components/common/layout/FixButtonBottom.tsx
+++ b/src/components/common/layout/FixButtonBottom.tsx
@@ -1,0 +1,32 @@
+/* eslint-disable react/require-default-props */
+/* eslint-disable import/no-cycle */
+import type { ReactNode } from 'react';
+
+import * as Layout from '@/components/common/layout';
+
+import type { FlexProps } from './index';
+
+type FlexPropsType<T extends FlexProps> = {
+  [K in keyof T]: T[K] | undefined;
+};
+
+function FixButtonBottom({
+  children,
+  ...flexProps
+}: { children: ReactNode } & FlexPropsType<FlexProps>) {
+  return (
+    <Layout.VStack
+      height='100%'
+      width='100%'
+      maxWidth='310px'
+      maxHeight='812px'
+      justifyContent='space-between'
+      style={{ overflowX: 'hidden', overflowY: 'auto' }}
+      {...(flexProps as FlexProps)}
+    >
+      {children}
+    </Layout.VStack>
+  );
+}
+
+export default FixButtonBottom;

--- a/src/components/common/layout/index.ts
+++ b/src/components/common/layout/index.ts
@@ -1,6 +1,7 @@
+/* eslint-disable import/no-cycle */
 import styled, { css } from 'styled-components';
 
-interface FlexProps extends SizeAndMarginAndPaddingProps {
+export interface FlexProps extends SizeAndMarginAndPaddingProps {
   flexDirection?: 'row' | 'column' | 'row-reverse' | 'column-reverse';
   justifyContent?:
     | 'flex-start'
@@ -68,3 +69,5 @@ export const Box = styled.div<SizeAndMarginAndPaddingProps>`
   display: block;
   ${SizeAndMarginAndPaddingProperty}
 `;
+
+export { default as FixButtonBottom } from '@/components/common/layout/FixButtonBottom';

--- a/src/components/keyword/index.tsx
+++ b/src/components/keyword/index.tsx
@@ -43,20 +43,15 @@ function Keyword({ product, allKeyword }: { product: Product; allKeyword: string
   };
 
   return (
-    <Layout.VStack
-      justifyContent='space-around'
-      height='100%'
-      width='100%'
-      maxWidth='310px'
-      alignItems='stretch'
-    >
-      <Layout.Box>
+    <Layout.FixButtonBottom alignItems='stretch' padding='0 0 30px 0'>
+      <Layout.VStack height='100%' justifyContent='center'>
         <Style.KeywordPageFont.Main>표시할 상품 키워드를 선택해 주세요.</Style.KeywordPageFont.Main>
         <Layout.Box height='4px' />
         <Style.KeywordPageFont.Sub>
           멋진 임명장을 위해선 7~14글자 사이가 좋아요!
         </Style.KeywordPageFont.Sub>
         <Layout.Box height='24px' />
+
         <Layout.HStack flexWrap='wrap' gap='8px 6px'>
           {allKeyword.map(keyword => (
             <Style.KeywordButton
@@ -68,7 +63,8 @@ function Keyword({ product, allKeyword }: { product: Product; allKeyword: string
             </Style.KeywordButton>
           ))}
         </Layout.HStack>
-        <Layout.Box margin='56px' />
+        <Layout.Box height='10%' />
+
         <Layout.VStack alignItems='stretch' gap='16px'>
           <Style.Span>{String(selectedKeywords).replaceAll(',', ' ')}</Style.Span>
           <Layout.HStack alignItems='center'>
@@ -78,9 +74,11 @@ function Keyword({ product, allKeyword }: { product: Product; allKeyword: string
             </Style.ResetBtn>
           </Layout.HStack>
         </Layout.VStack>
-      </Layout.Box>
+        <Layout.Box height='10%' />
+      </Layout.VStack>
+
       <BottomButton onClick={nextPageHandler}>다음으로</BottomButton>
-    </Layout.VStack>
+    </Layout.FixButtonBottom>
   );
 }
 

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -57,6 +57,7 @@ export const FixedWidth = styled.div`
 
 const Content = styled.div<{ heightRestrict?: boolean }>`
   flex: auto;
+  overflow: hidden;
   width: 100%;
   display: flex;
   flex-direction: column;

--- a/src/components/savingamount/styles.ts
+++ b/src/components/savingamount/styles.ts
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import * as Icon from '@/assets/Icons';
 import { DefaultInput } from '@/components/common/input';
 import * as Layout from '@/components/common/layout';
+import * as Font from '@/styles/font';
 
 export const Span = styled.span`
   ${DefaultInput}
@@ -52,4 +53,8 @@ export const ButtonStyleInit = styled.button`
   padding: 0;
   overflow: visible;
   cursor: pointer;
+`;
+
+export const KeepAllFont = styled(Font.Medium)`
+  word-break: keep-all;
 `;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState, useRef, RefObject } from 'react';
 
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
+import styled from 'styled-components';
 
 import { MainImage } from '@/assets/Images';
 import SearchInput from '@/components/SearchInput';
@@ -53,12 +54,7 @@ function Home() {
   }
 
   return (
-    <Layout.VStack
-      margin='20px 0 0'
-      width='100%'
-      alignItems='center'
-      style={{ overflow: 'hidden' }}
-    >
+    <ScrollY width='100%' padding='30px 0 30px' alignItems='center' style={{ overflow: 'auto' }}>
       {experienceOnboarding === AFTER_ABOUT && searchInputPositionAndSize && (
         <OnboardingDimmed
           searchInputInfo={searchInputPositionAndSize}
@@ -73,13 +69,13 @@ function Home() {
       <Layout.VStack ref={searchInputRef} width='100%' alignItems='center'>
         <SearchInput />
       </Layout.VStack>
-      <Layout.HStack margin='66px 0 0' gap='8px'>
+      <Layout.HStack margin='10vh 0 ' gap='8px'>
         <FacebookButton pageUrl={url} />
         <TwitterButton pageUrl={url} sendText={text} />
         <KakaoButton webUrl={url} />
         <LinkButton pageUrl={url} />
       </Layout.HStack>
-    </Layout.VStack>
+    </ScrollY>
   );
 }
 export default Home;
@@ -125,3 +121,17 @@ function calculatePositionAndSizeOfSearchInput(
 
   return calculatePosition;
 }
+
+const ScrollY = styled(Layout.VStack)`
+  ::-webkit-scrollbar,
+  ::-webkit-scrollbar-thumb {
+    width: 4px;
+    border-radius: 2px;
+    background-clip: padding-box;
+    border: 10px solid transparent;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: ${({ theme }) => theme.colors.gray[2]};
+  }
+`;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -53,7 +53,12 @@ function Home() {
   }
 
   return (
-    <Layout.VStack margin='20px 0 0' width='100%' alignItems='center'>
+    <Layout.VStack
+      margin='20px 0 0'
+      width='100%'
+      alignItems='center'
+      style={{ overflow: 'hidden' }}
+    >
       {experienceOnboarding === AFTER_ABOUT && searchInputPositionAndSize && (
         <OnboardingDimmed
           searchInputInfo={searchInputPositionAndSize}

--- a/src/pages/savingamount/index.tsx
+++ b/src/pages/savingamount/index.tsx
@@ -2,17 +2,13 @@ import { useState, useEffect, useRef, Dispatch, SetStateAction } from 'react';
 
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
-import styled from 'styled-components';
 
-import * as Icon from '@/assets/Icons';
 import { useSearchDispatch, useSearchStore } from '@/components/SearchProvider';
-import { BottomButton, DefaultTagStyle } from '@/components/common/buttons';
-import { DefaultInput } from '@/components/common/input';
+import { BottomButton } from '@/components/common/buttons';
 import * as Layout from '@/components/common/layout';
 import SavingAmountOptions from '@/components/savingamount/SavingAmountOptions';
 import * as Style from '@/components/savingamount/styles';
 import { InputRegExp } from '@/constant';
-import * as Font from '@/styles/font';
 
 const NoticeModal = dynamic(() => import('@/components/modal/NoticeModal'), { ssr: false });
 
@@ -60,29 +56,37 @@ const SavingAmount = () => {
   };
 
   return (
-    <Layout.VStack height='100%' justifyContent='space-around'>
-      <Layout.VStack alignItems='flex-start' gap='16px'>
+    <Layout.FixButtonBottom alignItems='center' padding='0 0 30px 0'>
+      <Layout.VStack
+        alignItems='flex-start'
+        gap='16px'
+        width='100%'
+        height='100%'
+        margin='41px 41px'
+        justifyContent='center'
+      >
         <Layout.HStack alignItems='center' gap='16px'>
           <Style.Span> {`${store.product.price?.toLocaleString()} ₩`} </Style.Span>
-          <Font.Medium>인</Font.Medium>
+          <Style.KeepAllFont>인</Style.KeepAllFont>
         </Layout.HStack>
 
         <Layout.HStack alignItems='center' gap='16px'>
           <Style.Span> {store.product.title} </Style.Span>
-          <Font.Medium>을(를) 갖기 위해</Font.Medium>
+          <Style.KeepAllFont>을(를) 갖기 위해</Style.KeepAllFont>
         </Layout.HStack>
 
         <Layout.HStack alignItems='center' gap='16px'>
           <Style.Span>한달</Style.Span>
-          <Font.Medium>동안</Font.Medium>
+          <Style.KeepAllFont>동안</Style.KeepAllFont>
         </Layout.HStack>
 
         <Layout.HStack alignItems='center' gap='16px'>
           <AmoutInput onChange={handleInputChange} resetAmount={setAmount} amount={amount} />
-          <Font.Medium>원을 모은다면?</Font.Medium>
+          <Style.KeepAllFont>원을 모은다면?</Style.KeepAllFont>
         </Layout.HStack>
         <SavingAmountOptions productPrice={store.product.price || 0} setAmount={setAmount} />
       </Layout.VStack>
+
       <Layout.Flex onClick={handleInputSubmit} justifyContent='center'>
         <BottomButton>다음으로</BottomButton>
       </Layout.Flex>
@@ -93,7 +97,7 @@ const SavingAmount = () => {
       {typingModal && (
         <NoticeModal onClose={() => setTypingModal(false)} message='모든 칸을 채워주세요!' />
       )}
-    </Layout.VStack>
+    </Layout.FixButtonBottom>
   );
 };
 
@@ -113,6 +117,7 @@ const AmoutInput = ({ onChange, resetAmount, amount }: AmountInput) => {
   return (
     <Style.InputBorder alignItems='center' focus={isFocus}>
       <Style.Input
+        type='text'
         onChange={e => onChange(e)}
         pattern='[0-9]*'
         inputMode='decimal'


### PR DESCRIPTION
#144 #143 과 관련된 내용들에 대해 추가 수정이 필요했던 부분을 작업했어요.
제가 일단 고쳐본 것들인데, 공통 레이아웃을 건들인 부분이 있어 토의가 필요할 듯 해요!
한번 읽어보시고 의견 부탁드려요 😄 

---

### applayout : `<Content>` 컴포넌트 overflow: hidden 추가
- Content 내부 요소들이 뷰포트보다 커짐에 따라 자동으로 전체 레이아웃에 스크롤 생성됨
- 따라서 **각 컴포넌트들이 자율적으로 scroll을 컨트롤 할 수 있도록 hidden 추가 제안**

#### PC ver
- hidden 을 적용하지 않았을때 이중으로 스크롤이 생기며, 외곽 스크롤을 하단으로 인디케이터가 보임

| before | after |
|--------|--------|
| ![overflow-hidden-none-pc-ver](https://github.com/SobiSa-Expense-Hunter/SobiSa/assets/108770949/7e8250e6-d427-43f1-84aa-c6b36fd0223f)| ![overflow-hidden-pc-ver](https://github.com/SobiSa-Expense-Hunter/SobiSa/assets/108770949/eb7d5f26-c048-4827-8a95-ea81e5365f58)| 

#### mobile ver
| before | after |
|--------|--------|
| ![overflow-hidden-none-android-ver gif](https://github.com/SobiSa-Expense-Hunter/SobiSa/assets/108770949/07cf0eb1-69dd-43da-9960-cb281e4e4924)| ![overflow-hidden-android-ver](https://github.com/SobiSa-Expense-Hunter/SobiSa/assets/108770949/f6ddd25a-d03e-4ab3-a172-82bfbbc4c773) | 

---

### main page : 스크롤이 다 되지 않던 문제
- 메인 컴포넌트의 가장 상위 컴포넌트에 overflow 추가

| before | after |
|--------|--------|
| ![main-before](https://github.com/SobiSa-Expense-Hunter/SobiSa/assets/108770949/d4454b06-46ac-4814-ba97-122d97adf3b3)|![overflow-hidden-android-ver](https://github.com/SobiSa-Expense-Hunter/SobiSa/assets/108770949/7324b260-b395-4a2f-a983-6742b77227f4)
 | 

---

### notfound 페이지 : 레이아웃 깨짐 문제
- common/error 컴포넌트의 가장 상위 컴포넌트에 overflow 추가

| before| after |
|--------|--------|
| ![notfound-before](https://github.com/SobiSa-Expense-Hunter/SobiSa/assets/108770949/443672d8-e70e-43ae-be0d-09dc18c44ee8)| ![notfound-after](https://github.com/SobiSa-Expense-Hunter/SobiSa/assets/108770949/a26379e1-5f5b-4bf9-baca-28747beee6d8)| 

---

### header : 배경 모스부호처럼 비쳐보이는 문제
- header 시작점을 -1px 으로 조절

| before| after|
|--------|--------|
|![image](https://github.com/SobiSa-Expense-Hunter/SobiSa/assets/108770949/76e3eba9-c41d-49f4-821e-205ebf454b23)| ![image](https://github.com/SobiSa-Expense-Hunter/SobiSa/assets/108770949/fd237685-9720-4081-8553-060717e84519)|


